### PR TITLE
add CLI argument syntax for input files which follows the UNIX way.

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,10 @@ doesn't exist b) the output file is older than the input file c) the header or
 footer have been modified since last build.
 
 ```
+# Put this in a file named GNUmakefile
+# and your Markdown sources in a subdir called "md".
+# Header and footer should be in "assets/header.html" and "assets/footer.html" respectively.
+# HTML output will be written to "html" sub-dir.
 DOCS := $(wildcard md/*.md)
 DOCS_HTML := $(patsubst md/%, html/%, $(patsubst %.md,%.html,$(DOCS)))
 ASSETS := $(wildcard assets/*.html)

--- a/README.md
+++ b/README.md
@@ -87,6 +87,32 @@ $ mdown -h
     --encoding <encoding>  File encoding. Defaults to "utf-8".
 ```
 
+### Markdown dependency-based compilation via GNU Make
+
+A common scenario is to want to generate HTML from a directory full of Markdown
+files. The HTML output also depends upon a header and a footer file. However,
+the HTML output files should only be updated if the output does not already
+exist, the corresponding source Markdown has changed since last build - or if
+either the header or footer has changed.
+
+This is the problem that the venerable UNIX make(1) command has been designed
+to solve. Using GNU make, the below sample will compile each Markdown file in a
+"md" subdirectory into a corresponding HTML output file in a "html"
+subdirectory. The `mdown` program will only be executed if a) the output file
+doesn't exist b) the output file is older than the input file c) the header or
+footer have been modified since last build.
+
+```
+DOCS := $(wildcard md/*.md)
+DOCS_HTML := $(patsubst md/%, html/%, $(patsubst %.md,%.html,$(DOCS)))
+ASSETS := $(wildcard assets/*.html)
+
+all: $(DOCS_HTML)
+
+html/%.html : md/%.md $(ASSETS)
+	mdown -o html/ --header "assets/header.html" --footer "assets/footer.html" $<
+```
+
 
 ## Important
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ command-line utility.
 ### Basic
 
 ```sh
-find -name '*.md' -exec mdown --output doc {} \;
+find . -name '*.md' -exec mdown --output doc {} \;
 ```
 
 This will convert any `.md` files it can find underneath the current directory

--- a/README.md
+++ b/README.md
@@ -24,23 +24,23 @@ command-line utility.
 ### Basic
 
 ```sh
-mdown --input "**/*.md" --output doc
+find -name '*.md' -exec mdown --output doc {} \;
 ```
 
-This will convert any `.md` files it can find inside the `--input` directory
+This will convert any `.md` files it can find underneath the current directory
 and it's child folders and output them into the `--output` folder.
 
 If you want to convert only files inside the directory itself but ignore child
-folders change the `--input` glob to `"*.md"`:
+folders change shell glob to `"*.md"`:
 
 ```sh
-mdown -i "src/*.md" -o doc
+mdown -o doc src/*.md
 ```
 
 And to convert just a single file and output it into the current folder:
 
 ```sh
-mdown -i "foo.md" -o .
+mdown -o . foo.md
 ```
 
 
@@ -50,7 +50,7 @@ mdown -i "foo.md" -o .
 You can specify HTML files to be used as header and footer of all the pages:
 
 ```sh
-mdown -i "*.md" -o dist --header "assets/header.html" --footer "assets/header.html"
+mdown -o dist --header "assets/header.html" --footer "assets/header.html" *.md
 ```
 
 
@@ -67,7 +67,6 @@ curl https://raw.github.com/millermedeiros/gh-markdown-cli/master/README.md | md
 
 If you don't specify the `--output` it will echo the result to `stdout` by default.
 
-
 ### More
 
 For a list of all available options run `mdown -h`:
@@ -75,14 +74,13 @@ For a list of all available options run `mdown -h`:
 ```
 $ mdown -h
 
-  Usage: mdown [options]
+  Usage: mdown [options] file ...
 
   Options:
 
     -h, --help             output usage information
     -V, --version          output the version number
     -o, --output <name>    Output directory or output file name if using stdin for input.
-    -i, --input <glob>     Glob used for inclusion. Eg: "**/*.md" will convert all the ".md" files inside current folder and all its child folders.
     --exclude <globs>      Comma separated list of globs used for exclusion. Defaults to "node_modules/**"
     --header <path>        Path to HTML file used as header on all documents.
     --footer <path>        Path to HTML file used as footer on all documents.

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ footer have been modified since last build.
 
 ```
 # Put this in a file named GNUmakefile
-# and your Markdown sources in a subdir called "md".
+# and your Markdown sources in a sub-dir called "md".
 # Header and footer should be in "assets/header.html" and "assets/footer.html" respectively.
 # HTML output will be written to "html" sub-dir.
 DOCS := $(wildcard md/*.md)

--- a/bin/mdown
+++ b/bin/mdown
@@ -8,6 +8,7 @@ _cli
     .version('0.2.0')
     .description('Batch convert markdown files into HTML.')
     .option('-o, --output <name>', 'Output directory or output file name if using stdin for input.')
+    .option('-i, --input <glob>', 'Glob used for inclusion. Eg: "**/*.md" will convert all the ".md" files inside current folder and all its child folders.')
     .option('--exclude <globs>', 'Comma separated list of globs used for exclusion. Defaults to "node_modules/**"', 'node_modules/**')
     .option('--header <path>', 'Path to HTML file used as header on all documents.')
     .option('--footer <path>', 'Path to HTML file used as footer on all documents.')
@@ -15,10 +16,9 @@ _cli
     .usage("[options] file ...")
 
 
-var argv = _cli.parse(process.argv);
-_cli.input = _cli.args;
+_cli.parse(process.argv);
 
-if (_cli.input.length > 0) {
+if (_cli.input || _cli.args.length > 0) {
     _mdown.batchProcess(_cli);
 } else {
     processStdIn();

--- a/bin/mdown
+++ b/bin/mdown
@@ -8,17 +8,17 @@ _cli
     .version('0.2.0')
     .description('Batch convert markdown files into HTML.')
     .option('-o, --output <name>', 'Output directory or output file name if using stdin for input.')
-    .option('-i, --input <glob>', 'Glob used for inclusion. Eg: "**/*.md" will convert all the ".md" files inside current folder and all its child folders.')
     .option('--exclude <globs>', 'Comma separated list of globs used for exclusion. Defaults to "node_modules/**"', 'node_modules/**')
     .option('--header <path>', 'Path to HTML file used as header on all documents.')
     .option('--footer <path>', 'Path to HTML file used as footer on all documents.')
-    .option('--encoding <encoding>', 'File encoding. Defaults to "utf-8".', 'utf-8');
+    .option('--encoding <encoding>', 'File encoding. Defaults to "utf-8".', 'utf-8')
+    .usage("[options] file ...")
 
 
-_cli.parse(process.argv);
+var argv = _cli.parse(process.argv);
+_cli.input = _cli.args;
 
-
-if (_cli.input) {
+if (_cli.input.length > 0) {
     _mdown.batchProcess(_cli);
 } else {
     processStdIn();

--- a/mdown.js
+++ b/mdown.js
@@ -1,7 +1,6 @@
 
 var _fs = require('fs'),
     _path = require('path'),
-    _glob = require('glob'),
     _minimatch = require('minimatch'),
     _wrench = require('wrench'),
     _showdown = require('github-flavored-markdown');
@@ -14,21 +13,19 @@ exports.batchProcess = function(opts){
 
     opts.encoding = opts.encoding || DEFAULT_ENCODING;
 
-    _glob(opts.input, null, function(er, files){
 
-        if (opts.exclude) {
-            files = filterFiles(files, opts.exclude);
+    var files = opts.input;
+    if (opts.exclude) {
+        files = filterFiles(files, opts.exclude);
+    }
+
+    files.forEach(function(filePath){
+        var content = exports.toHTML(_fs.readFileSync(filePath, opts.encoding), opts);
+        if (opts.output) {
+            outputToFile(filePath, content, opts);
+        } else {
+            console.log(content);
         }
-
-        files.forEach(function(filePath){
-            var content = exports.toHTML(_fs.readFileSync(filePath, opts.encoding), opts);
-            if (opts.output) {
-                outputToFile(filePath, content, opts);
-            } else {
-                console.log(content);
-            }
-        });
-
     });
 };
 
@@ -44,7 +41,7 @@ function filterFiles(files, exclude) {
 
 
 function outputToFile(filePath, content, opts){
-    var inputDir = opts.input.replace(/^([^\*]*).*/, '$1'),
+  var inputDir = _path.dirname(filePath),
         rPathReplace = new RegExp('^'+ inputDir +'(.+)'),
         distPath = filePath.replace(rPathReplace, function(str, p1){
             return _path.join(opts.output, p1).replace(/\.[^\.]+$/, '.html');

--- a/mdown.js
+++ b/mdown.js
@@ -1,5 +1,6 @@
 
 var _fs = require('fs'),
+    _glob = require('glob'),
     _path = require('path'),
     _minimatch = require('minimatch'),
     _wrench = require('wrench'),
@@ -12,21 +13,29 @@ var DEFAULT_ENCODING = 'utf-8';
 exports.batchProcess = function(opts){
 
     opts.encoding = opts.encoding || DEFAULT_ENCODING;
+    if (!opts.input || opts.input.length === 0) {
+      processFiles(null, []);
+    } else {
+      _glob(opts.input, null, processFiles);
+    }
+    function processFiles(err, files) {
+      files = files.concat(opts.args);
 
+      if (opts.exclude) {
+          files = filterFiles(files, opts.exclude);
+      }
 
-    var files = opts.input;
-    if (opts.exclude) {
-        files = filterFiles(files, opts.exclude);
+      files.forEach(function(filePath){
+          var content = exports.toHTML(_fs.readFileSync(filePath, opts.encoding), opts);
+          if (opts.output) {
+              outputToFile(filePath, content, opts);
+          } else {
+              console.log(content);
+          }
+      });
+
     }
 
-    files.forEach(function(filePath){
-        var content = exports.toHTML(_fs.readFileSync(filePath, opts.encoding), opts);
-        if (opts.output) {
-            outputToFile(filePath, content, opts);
-        } else {
-            console.log(content);
-        }
-    });
 };
 
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "description" : "Batch convert Github flavored markdown files through the command-line.",
     "keywords" : ["markdown", "generator", "cli"],
     "homepage" : "https://github.com/millermedeiros/gh-markdown-cli",
-    "version" : "0.2.1",
+    "version" : "0.3.0",
     "author" : {
         "name" : "Miller Medeiros",
         "url" : "http://blog.millermedeiros.com/"
@@ -22,6 +22,7 @@
         }
     ],
     "dependencies" : {
+        "glob": ">=3.1.10",
         "wrench" : ">= 1.3.2",
         "github-flavored-markdown" : ">= 1.0.0",
         "minimatch" : ">= 0.1.0",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "description" : "Batch convert Github flavored markdown files through the command-line.",
     "keywords" : ["markdown", "generator", "cli"],
     "homepage" : "https://github.com/millermedeiros/gh-markdown-cli",
-    "version" : "0.2.0",
+    "version" : "0.2.1",
     "author" : {
         "name" : "Miller Medeiros",
         "url" : "http://blog.millermedeiros.com/"
@@ -24,7 +24,6 @@
     "dependencies" : {
         "wrench" : ">= 1.3.2",
         "github-flavored-markdown" : ">= 1.0.0",
-        "glob" : ">= 3.0.0",
         "minimatch" : ">= 0.1.0",
         "commander" : ">= 0.4.0"
     },

--- a/package.json
+++ b/package.json
@@ -28,9 +28,16 @@
         "minimatch" : ">= 0.1.0",
         "commander" : ">= 0.4.0"
     },
+    "devDependencies": {
+        "chai": ">=1.0.4",
+        "mocha": ">=1.1.0"
+    },
     "main" : "mdown.js",
     "bin" : {
         "mdown" : "bin/mdown"
     },
-    "preferGlobal" : true
+    "preferGlobal" : true,
+    "scripts" : {
+        "test" : "node_modules/mocha/bin/mocha -R tap tests"
+    }
 }

--- a/tests/foodir/bosh.md
+++ b/tests/foodir/bosh.md
@@ -1,0 +1,4 @@
+fo fo0
+
+
+this is a test document

--- a/tests/test.js
+++ b/tests/test.js
@@ -1,0 +1,41 @@
+var expect = require('chai').expect,
+    exec = require('child_process').exec
+    ;
+
+
+describe("CLI", function() {
+  it ("should work with both --input and UNIX-style argv filename input", function(done) {
+
+    var p = exec('bin/mdown --input "*.md"', function(err, stdout, stderr) {
+      if (err) throw err;
+
+      var p2 = exec('bin/mdown *.md', function(err, stdout2, stderr2) {
+        if (err) throw err;
+
+        expect(stdout2.length).to.be.above(0);
+        expect(stdout.length).to.be.above(0);
+        expect(stdout2).to.equal(stdout);
+        expect(stderr2).to.equal(stderr);
+
+        done();
+
+      });
+    });
+  });
+
+  it ("should be compatible with find(1) UNIX-style argv filename input", function(done) {
+    this.timeout(10000);
+
+    var p = exec('find tests/ -name "*.md" -exec bin/mdown {} \\;', function(err, stdout, stderr) {
+      if (err) throw err;
+      var p2 = exec('bin/mdown --input "tests/**/*.md"', function(err, stdout2, stderr2) {
+        expect(stdout2.length).to.be.above(0);
+        expect(stdout.length).to.be.above(0);
+        expect(stdout2).to.equal(stdout);
+        expect(stderr2).to.equal(stderr);
+
+        done();
+      });
+    });
+  });
+});


### PR DESCRIPTION
in addition to having an explicit --input <glob> option, use the regular
method of supporting unlimited file arguments. thus operation becomes:

mdown *.md

as opposed to

mdown --input '*.md'

and

find . -name '*.md' -exec mdown {} \;

as opposed to

mdown --input '*_/_.md'

this allows mdown to work properly with build-in shell globbing, Make
and other standard UNIX tools like find(1) and xargs(1)
